### PR TITLE
Update minecraft plugin for new versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,13 @@
 
     <groupId>com.lthoerner</groupId>
     <artifactId>BetterAnvils</artifactId>
-    <version>0.1.2</version>
+    <version>0.1.3</version>
     <packaging>jar</packaging>
 
     <name>BetterAnvils</name>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>21</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -21,7 +21,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.13.0</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
@@ -30,7 +30,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -67,13 +67,13 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.20.1-R0.1-SNAPSHOT</version>
+            <version>1.21.8-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>RELEASE</version>
+            <version>24.1.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/lthoerner/betteranvils/AnvilUtils.java
+++ b/src/main/java/com/lthoerner/betteranvils/AnvilUtils.java
@@ -400,7 +400,7 @@ class AnvilUtils {
                 return DamageableMaterial.DIAMOND;
             case NETHERITE_INGOT:
                 return DamageableMaterial.NETHERITE;
-            case SCUTE:
+            case TURTLE_SCUTE:
                 return DamageableMaterial.SCUTE;
             case PHANTOM_MEMBRANE:
                 return DamageableMaterial.PHANTOM_MEMBRANE;

--- a/src/main/java/com/lthoerner/betteranvils/EnchantUtils.java
+++ b/src/main/java/com/lthoerner/betteranvils/EnchantUtils.java
@@ -69,62 +69,62 @@ class EnchantUtils {
         int CURSE_OF_BINDING_LEVEL = USE_VANILLA_MAX_LEVELS ? 1 : config.getInt("max-level.curse-of-binding");
         int CURSE_OF_VANISHING_LEVEL = USE_VANILLA_MAX_LEVELS ? 1 : config.getInt("max-level.curse-of-vanishing");
 
-        MAX_ENCHANT_LEVELS.put(Enchantment.DAMAGE_ALL, SHARPNESS_LEVEL);
-        MAX_ENCHANT_LEVELS.put(Enchantment.DAMAGE_UNDEAD, SMITE_LEVEL);
-        MAX_ENCHANT_LEVELS.put(Enchantment.DAMAGE_ARTHROPODS, BANE_OF_ARTHROPODS_LEVEL);
+        MAX_ENCHANT_LEVELS.put(Enchantment.SHARPNESS, SHARPNESS_LEVEL);
+        MAX_ENCHANT_LEVELS.put(Enchantment.SMITE, SMITE_LEVEL);
+        MAX_ENCHANT_LEVELS.put(Enchantment.BANE_OF_ARTHROPODS, BANE_OF_ARTHROPODS_LEVEL);
         MAX_ENCHANT_LEVELS.put(Enchantment.FIRE_ASPECT, FIRE_ASPECT_LEVEL);
         MAX_ENCHANT_LEVELS.put(Enchantment.KNOCKBACK, KNOCKBACK_LEVEL);
-        MAX_ENCHANT_LEVELS.put(Enchantment.LOOT_BONUS_MOBS, LOOTING_LEVEL);
+        MAX_ENCHANT_LEVELS.put(Enchantment.LOOTING, LOOTING_LEVEL);
         MAX_ENCHANT_LEVELS.put(Enchantment.SWEEPING_EDGE, SWEEPING_EDGE_LEVEL);
 
         MAX_ENCHANT_LEVELS.put(Enchantment.IMPALING, IMPALING_LEVEL);
         MAX_ENCHANT_LEVELS.put(Enchantment.RIPTIDE, RIPTIDE_LEVEL);
         MAX_ENCHANT_LEVELS.put(Enchantment.LOYALTY, LOYALTY_LEVEL);
 
-        MAX_ENCHANT_LEVELS.put(Enchantment.ARROW_DAMAGE, POWER_LEVEL);
-        MAX_ENCHANT_LEVELS.put(Enchantment.ARROW_FIRE, FLAME_LEVEL);
-        MAX_ENCHANT_LEVELS.put(Enchantment.ARROW_KNOCKBACK, PUNCH_LEVEL);
-        MAX_ENCHANT_LEVELS.put(Enchantment.ARROW_INFINITE, INFINITY_LEVEL);
+        MAX_ENCHANT_LEVELS.put(Enchantment.POWER, POWER_LEVEL);
+        MAX_ENCHANT_LEVELS.put(Enchantment.FLAME, FLAME_LEVEL);
+        MAX_ENCHANT_LEVELS.put(Enchantment.PUNCH, PUNCH_LEVEL);
+        MAX_ENCHANT_LEVELS.put(Enchantment.INFINITY, INFINITY_LEVEL);
 
         MAX_ENCHANT_LEVELS.put(Enchantment.PIERCING, PIERCING_LEVEL);
         MAX_ENCHANT_LEVELS.put(Enchantment.QUICK_CHARGE, QUICK_CHARGE_LEVEL);
         MAX_ENCHANT_LEVELS.put(Enchantment.MULTISHOT, MULTISHOT_LEVEL);
 
-        MAX_ENCHANT_LEVELS.put(Enchantment.DIG_SPEED, EFFICIENCY_LEVEL);
-        MAX_ENCHANT_LEVELS.put(Enchantment.LOOT_BONUS_BLOCKS, FORTUNE_LEVEL);
+        MAX_ENCHANT_LEVELS.put(Enchantment.EFFICIENCY, EFFICIENCY_LEVEL);
+        MAX_ENCHANT_LEVELS.put(Enchantment.FORTUNE, FORTUNE_LEVEL);
         MAX_ENCHANT_LEVELS.put(Enchantment.SILK_TOUCH, SILK_TOUCH_LEVEL);
 
         MAX_ENCHANT_LEVELS.put(Enchantment.LURE, LURE_LEVEL);
-        MAX_ENCHANT_LEVELS.put(Enchantment.LUCK, LUCK_OF_THE_SEA_LEVEL);
+        MAX_ENCHANT_LEVELS.put(Enchantment.LUCK_OF_THE_SEA, LUCK_OF_THE_SEA_LEVEL);
 
-        MAX_ENCHANT_LEVELS.put(Enchantment.PROTECTION_ENVIRONMENTAL, PROTECTION_LEVEL);
-        MAX_ENCHANT_LEVELS.put(Enchantment.PROTECTION_FIRE, FIRE_PROTECTION_LEVEL);
-        MAX_ENCHANT_LEVELS.put(Enchantment.PROTECTION_PROJECTILE, PROJECTILE_PROTECTION_LEVEL);
-        MAX_ENCHANT_LEVELS.put(Enchantment.PROTECTION_EXPLOSIONS, BLAST_PROTECTION_LEVEL);
-        MAX_ENCHANT_LEVELS.put(Enchantment.PROTECTION_FALL, FEATHER_FALLING_LEVEL);
+        MAX_ENCHANT_LEVELS.put(Enchantment.PROTECTION, PROTECTION_LEVEL);
+        MAX_ENCHANT_LEVELS.put(Enchantment.FIRE_PROTECTION, FIRE_PROTECTION_LEVEL);
+        MAX_ENCHANT_LEVELS.put(Enchantment.PROJECTILE_PROTECTION, PROJECTILE_PROTECTION_LEVEL);
+        MAX_ENCHANT_LEVELS.put(Enchantment.BLAST_PROTECTION, BLAST_PROTECTION_LEVEL);
+        MAX_ENCHANT_LEVELS.put(Enchantment.FEATHER_FALLING, FEATHER_FALLING_LEVEL);
         MAX_ENCHANT_LEVELS.put(Enchantment.THORNS, THORNS_LEVEL);
         MAX_ENCHANT_LEVELS.put(Enchantment.SOUL_SPEED, SOUL_SPEED_LEVEL);
         MAX_ENCHANT_LEVELS.put(Enchantment.SWIFT_SNEAK, SWIFT_SNEAK_LEVEL);
         MAX_ENCHANT_LEVELS.put(Enchantment.DEPTH_STRIDER, DEPTH_STRIDER_LEVEL);
-        MAX_ENCHANT_LEVELS.put(Enchantment.OXYGEN, RESPIRATION_LEVEL);
-        MAX_ENCHANT_LEVELS.put(Enchantment.WATER_WORKER, AQUA_AFFINITY_LEVEL);
+        MAX_ENCHANT_LEVELS.put(Enchantment.RESPIRATION, RESPIRATION_LEVEL);
+        MAX_ENCHANT_LEVELS.put(Enchantment.AQUA_AFFINITY, AQUA_AFFINITY_LEVEL);
         MAX_ENCHANT_LEVELS.put(Enchantment.FROST_WALKER, FROST_WALKER_LEVEL);
 
-        MAX_ENCHANT_LEVELS.put(Enchantment.DURABILITY, UNBREAKING_LEVEL);
+        MAX_ENCHANT_LEVELS.put(Enchantment.UNBREAKING, UNBREAKING_LEVEL);
         MAX_ENCHANT_LEVELS.put(Enchantment.MENDING, MENDING_LEVEL);
 
         MAX_ENCHANT_LEVELS.put(Enchantment.BINDING_CURSE, CURSE_OF_BINDING_LEVEL);
         MAX_ENCHANT_LEVELS.put(Enchantment.VANISHING_CURSE, CURSE_OF_VANISHING_LEVEL);
 
         INCOMPATIBLE_ENCHANTMENTS.add(new Enchantment[] {
-                Enchantment.DAMAGE_ALL,
-                Enchantment.DAMAGE_UNDEAD,
-                Enchantment.DAMAGE_ARTHROPODS,
+                Enchantment.SHARPNESS,
+                Enchantment.SMITE,
+                Enchantment.BANE_OF_ARTHROPODS,
         });
 
         INCOMPATIBLE_ENCHANTMENTS.add(new Enchantment[] {
                 Enchantment.MENDING,
-                Enchantment.ARROW_INFINITE,
+                Enchantment.INFINITY,
         });
 
         INCOMPATIBLE_ENCHANTMENTS.add(new Enchantment[] {
@@ -133,15 +133,15 @@ class EnchantUtils {
         });
 
         INCOMPATIBLE_ENCHANTMENTS.add(new Enchantment[] {
-                Enchantment.LOOT_BONUS_BLOCKS,
+                Enchantment.FORTUNE,
                 Enchantment.SILK_TOUCH,
         });
 
         INCOMPATIBLE_ENCHANTMENTS.add(new Enchantment[] {
-                Enchantment.PROTECTION_ENVIRONMENTAL,
-                Enchantment.PROTECTION_FIRE,
-                Enchantment.PROTECTION_PROJECTILE,
-                Enchantment.PROTECTION_EXPLOSIONS,
+                Enchantment.PROTECTION,
+                Enchantment.FIRE_PROTECTION,
+                Enchantment.PROJECTILE_PROTECTION,
+                Enchantment.BLAST_PROTECTION,
         });
 
         INCOMPATIBLE_ENCHANTMENTS.add(new Enchantment[] {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,4 +1,4 @@
 name: BetterAnvils
-version: '0.1.2'
+version: '0.1.3'
 main: com.lthoerner.betteranvils.BetterAnvils
-api-version: '1.20'
+api-version: '1.21'


### PR DESCRIPTION
Update BetterAnvils plugin to support Minecraft 1.21.7 and 1.21.8, including API and dependency updates, and migration of deprecated enchantment and material constants.

---
<a href="https://cursor.com/background-agent?bcId=bc-ef47cd77-e142-462c-b5e6-5e87ee8a69f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ef47cd77-e142-462c-b5e6-5e87ee8a69f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

